### PR TITLE
Update Helm Chart to Run as Non-Root User in OpenShift

### DIFF
--- a/charts/presto/Chart.yaml
+++ b/charts/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: presto
 description: The official Helm chart for Presto
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.288"
 home: https://prestodb.io
 icon: https://prestodb.io/docs/current/_static/logo.png

--- a/charts/presto/templates/deployment-coordinator.yaml
+++ b/charts/presto/templates/deployment-coordinator.yaml
@@ -8,6 +8,7 @@
 {{- $affinity := or .Values.coordinator.affinity .Values.affinity }}
 {{- $tolerations := or .Values.coordinator.tolerations .Values.tolerations }}
 {{- $securityContext := or .Values.coordinator.securityContext .Values.securityContext }}
+{{- $podSecurityContext := or .Values.coordinator.podSecurityContext .Values.podSecurityContext }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -51,6 +52,9 @@ spec:
         - name: coordinator
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with $securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.coordinator.command }}
           command: {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
@@ -130,6 +134,6 @@ spec:
       {{- with $tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $securityContext }}
+      {{- with $podSecurityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/presto/templates/deployment-resource-manager.yaml
+++ b/charts/presto/templates/deployment-resource-manager.yaml
@@ -8,6 +8,7 @@
 {{- $affinity := or .Values.resourceManager.affinity .Values.affinity }}
 {{- $tolerations := or .Values.resourceManager.tolerations .Values.tolerations }}
 {{- $securityContext := or .Values.resourceManager.securityContext .Values.securityContext }}
+{{- $podSecurityContext := or .Values.resourceManager.podSecurityContext .Values.podSecurityContext }}
 {{- if eq .Values.mode "ha-cluster" }}
 apiVersion: apps/v1
 kind: Deployment
@@ -52,6 +53,9 @@ spec:
         - name: resource-manager
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with $securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.resourceManager.command }}
           command: {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
@@ -124,7 +128,7 @@ spec:
       {{- with $tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $securityContext }}
+      {{- with $podSecurityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/presto/templates/deployment-worker.yaml
+++ b/charts/presto/templates/deployment-worker.yaml
@@ -9,6 +9,7 @@
 {{- $tolerations := or .Values.worker.tolerations .Values.tolerations }}
 {{- $securityContext := or .Values.worker.securityContext .Values.securityContext }}
 {{- if or (eq .Values.mode "cluster") (eq .Values.mode "ha-cluster") }}
+{{- $podSecurityContext := or .Values.worker.podSecurityContext .Values.podSecurityContext }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -52,6 +53,9 @@ spec:
         - name: worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with $securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.worker.command }}
           command: {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
@@ -122,7 +126,7 @@ spec:
       {{- with $tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $securityContext }}
+      {{- with $podSecurityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
This pull request updates the PrestoDB Helm chart to support deployment on OpenShift with the necessary configurations to run as a non-root user. The changes include:

- Adding `securityContext` and `podSecurityContext` configurations in the Helm chart to specify non-root user settings.
- Updating `values.yaml` with default values for `runAsUser`, `runAsNonRoot`, and `fsGroup` to ensure compatibility with OpenShift's security constraints.

**Issue:**

In the current Helm chart, when deploying in OpenShift as a non-root user, the container is unable to create the required data directory due to permission restrictions. To address this, we need to apply privileged permissions in the container's security context (`securityContext.privileged: true`) to allow the creation of the data directory and proper access management.

These updates allow the Helm chart to be used in environments where running containers as a root user is restricted, such as OpenShift.