### PR TITLE
Add support for Velox based workers to the Presto helm chart

### DIFF
--- a/charts/presto/templates/configmap-coordinator.yaml
+++ b/charts/presto/templates/configmap-coordinator.yaml
@@ -29,7 +29,15 @@ data:
     discovery-server.enabled={{ or (eq .Values.mode "single") (eq .Values.mode "cluster") }}
     node-scheduler.include-coordinator={{ eq .Values.mode "single" }}
     resource-manager-enabled={{ eq .Values.mode "ha-cluster" }}
-    {{- .Values.config | nindent 4 }}
+    presto.version={{ .Values.image.tag | default .Chart.AppVersion }}{{- if .Values.prestoCpp.enabled }}wCPP{{ .Values.prestoCpp.image.tag }}{{- end }}
+    {{- if .Values.prestoCpp.enabled }}
+    native-execution-enabled=true
+    optimizer.optimize-hash-generation=false
+    regex-library=RE2J
+    use-alternative-function-signatures=true
+    experimental.table-writer-merge-operator-enabled=false
+    {{- end }}
+    {{- .Values.coordinator.config | default .Values.config | nindent 4 }}
   log.properties: |-
     {{- .Values.log | nindent 4 }}
   {{- if .Values.resourceGroups.manager }}

--- a/charts/presto/templates/configmap-resource-manager.yaml
+++ b/charts/presto/templates/configmap-resource-manager.yaml
@@ -33,7 +33,8 @@ data:
     resource-manager=true
     thrift.server.port=8081
     thrift.server.ssl.enabled=false
-    {{- .Values.config | nindent 4 }}
+    presto.version={{ .Values.image.tag | default .Chart.AppVersion }}{{- if .Values.prestoCpp.enabled }}wCPP{{ .Values.prestoCpp.image.tag }}{{- end }}
+    {{- .Values.resourceManager.config | default .Values.config | nindent 4 }}
   log.properties: |-
     {{- .Values.log | nindent 4 }}
   {{- if .Values.metrics.enabled }}

--- a/charts/presto/templates/configmap-worker.yaml
+++ b/charts/presto/templates/configmap-worker.yaml
@@ -28,7 +28,8 @@ data:
     http-server.http.port={{ .Values.service.port }}
     discovery.uri=http://{{ .Release.Name }}-discovery:{{ .Values.service.port }}
     resource-manager-enabled={{ eq .Values.mode "ha-cluster" }}
-    {{- .Values.config | nindent 4 }}
+    presto.version={{ .Values.image.tag | default .Chart.AppVersion }}{{- if .Values.prestoCpp.enabled }}wCPP{{ .Values.prestoCpp.image.tag }}{{- end }}
+    {{- .Values.worker.config | default .Values.config | nindent 4 }}
   log.properties: |-
     {{- .Values.log | nindent 4 }}
   {{- if .Values.metrics.enabled }}

--- a/charts/presto/templates/deployment-worker.yaml
+++ b/charts/presto/templates/deployment-worker.yaml
@@ -50,8 +50,8 @@ spec:
       {{- end }}
       containers:
         - name: worker
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ if .Values.prestoCpp.enabled }}{{ .Values.prestoCpp.image.repository }}:{{ .Values.prestoCpp.image.tag | default .Chart.AppVersion }}{{ else }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ end }}"
+          imagePullPolicy: {{ if .Values.prestoCpp.enabled }}{{ .Values.prestoCpp.image.pullPolicy }}{{ else }}{{ .Values.image.pullPolicy }}{{ end }}
           {{- with .Values.worker.command }}
           command: {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}

--- a/charts/presto/values.yaml
+++ b/charts/presto/values.yaml
@@ -90,6 +90,8 @@ log: |-
 resourceManager:
   # Resource manager JVM options (overwrites common JVM options)
   jvm: ""
+  # Resource manager configuration properties (overwrites common config options)
+  config: ~
   # Command to launch resource manager (templated)
   command: ~
   # Arguments to launch resource manager (templated)
@@ -142,6 +144,8 @@ coordinator:
   replicas: 1
   # Coordinator JVM options (overwrites common JVM options)
   jvm: ""
+  # Coordinator configuration properties (overwrites common config options)
+  config: ~
   # Command to launch coordinator (templated)
   command: ~
   # Arguments to launch coordinator (templated)
@@ -194,6 +198,8 @@ worker:
   replicas: 2
   # Worker JVM options (overwrites common JVM options)
   jvm: ""
+  # Worker configuration properties (overwrites common config options)
+  config: ~
   # Command to launch worker (templated)
   command: ~
   # Arguments to launch worker (templated)
@@ -239,6 +245,15 @@ worker:
   tolerations: []
   # Worker security context (overwrites default security context)
   securityContext: {}
+  
+# Enables Presto to use C++ based workers  
+prestoCpp: 
+  enabled: false
+  # Image details for Presto C++ workers (overrides common image details)
+  image:
+    repository: prestodb/presto-native
+    pullPolicy: IfNotPresent
+    tag: ~
 
 # Catalogs
 catalog: {}


### PR DESCRIPTION
## Description
This pull request adds optional support for using the helm chart with Velox workers. It adds a Velox tree to the values.yaml allowing the user to define if Velox is enabled. When enabled, the worker's image and relavant aspects of configuration are overridden by a customizable Velox based configuration. If Velox is disabled, the helm chart will continue to function as previously. Additionally, this pull request allows the presto configuation properties to be configurable seperately for the coordinator and workers as this can be useful for both Velox and non-Velox scenarios

## Motivation and Context
Up until now the helm chart only supports regular Java based Presto. This means that users wanting to utilize Presto with Velox workers would need to find a different option for deployment. This PR seeks to resolve that by enabling Velox based workers to be deployed via the helm chart without impacting any of the existing functionality for those who prefer to use traditional java based workers.

## Impact
Additional options in values.yaml

## Test Plan
Deployed  and ran queries on my AWS based cluster with velox.enabled both true and false checking the settings took affect. Also deployed with edited config.properties and velox.properties ensuring that edits were applied to the cluster.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes